### PR TITLE
log every 404 to Turso to clean up the WordPress migration

### DIFF
--- a/scripts/page-misses-report.py
+++ b/scripts/page-misses-report.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+Top 404 paths from the Quina Care page_misses table.
+
+Pure stdlib — talks to Turso over its HTTP pipeline API, no
+pip install required.
+
+Usage:
+  python page-misses-report.py [--since YYYY-MM-DD]
+                               [--limit N]
+                               [--include-bots]
+
+Credentials (CLI flags win; otherwise env):
+  --url URL       Turso database URL (libsql:// or https://)
+  --token TOKEN   Turso auth token
+  TURSO_DATABASE_URL / TURSO_AUTH_TOKEN environment variables
+
+Default scope: human traffic, last 30 days, top 50 paths.
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Top 404 paths")
+    p.add_argument("--url", help="Turso database URL (or TURSO_DATABASE_URL env)")
+    p.add_argument("--token", help="Turso auth token (or TURSO_AUTH_TOKEN env)")
+    p.add_argument(
+        "--since",
+        help="Only include hits on/after this ISO date (default: last 30 days)",
+    )
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Top N paths to show (default: 50)",
+    )
+    p.add_argument(
+        "--include-bots",
+        action="store_true",
+        help="Also show the top bot-tagged paths in a separate table",
+    )
+    return p.parse_args()
+
+
+def _typed_arg(a):
+    if a is None:
+        return {"type": "null", "value": None}
+    if isinstance(a, int):
+        return {"type": "integer", "value": str(a)}
+    return {"type": "text", "value": str(a)}
+
+
+def _parse_cell(cell):
+    t = cell.get("type")
+    if t == "null":
+        return None
+    v = cell.get("value")
+    if t == "integer":
+        return int(v)
+    if t in ("float", "real"):
+        return float(v)
+    return v
+
+
+def execute(url, token, sql, args=None):
+    if url.startswith("libsql://"):
+        url = "https://" + url[len("libsql://") :]
+    payload = json.dumps(
+        {
+            "requests": [
+                {
+                    "type": "execute",
+                    "stmt": {"sql": sql, "args": [_typed_arg(a) for a in (args or [])]},
+                },
+                {"type": "close"},
+            ]
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        f"{url.rstrip('/')}/v2/pipeline",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        raise SystemExit(f"Turso HTTP {e.code}: {e.read().decode('utf-8', 'replace')}")
+    except urllib.error.URLError as e:
+        raise SystemExit(f"Turso connection failed: {e.reason}")
+    res = data["results"][0]
+    if res.get("type") == "error":
+        raise SystemExit(f"Turso error: {res.get('error', {}).get('message', res)}")
+    cols = [c["name"] for c in res["response"]["result"]["cols"]]
+    return [
+        {cols[i]: _parse_cell(r[i]) for i in range(len(cols))}
+        for r in res["response"]["result"]["rows"]
+    ]
+
+
+def top_paths(url, token, since, limit, is_bot):
+    rows = execute(
+        url,
+        token,
+        """
+        SELECT path,
+               COUNT(*) AS hits,
+               COUNT(DISTINCT user_agent) AS distinct_ua,
+               MAX(created_at) AS last_seen
+        FROM page_misses
+        WHERE created_at >= ? AND is_bot = ?
+        GROUP BY path
+        ORDER BY hits DESC
+        LIMIT ?
+        """,
+        [since, 1 if is_bot else 0, limit],
+    )
+    return rows
+
+
+def fmt_table(title, rows):
+    out = [title, "=" * len(title), ""]
+    if not rows:
+        out.append("  (none)")
+        return "\n".join(out)
+    out.append(
+        f"  {'hits':>6}  {'UAs':>4}  {'last seen':<19}  path",
+    )
+    out.append(f"  {'-' * 6}  {'-' * 4}  {'-' * 19}  {'-' * 60}")
+    for r in rows:
+        out.append(
+            f"  {r['hits']:>6}  {r['distinct_ua']:>4}  "
+            f"{(r['last_seen'] or '')[:19]:<19}  {r['path']}"
+        )
+    return "\n".join(out)
+
+
+def main():
+    args = parse_args()
+    url = args.url or os.environ.get("TURSO_DATABASE_URL")
+    token = args.token or os.environ.get("TURSO_AUTH_TOKEN")
+    if not url or not token:
+        sys.exit("missing TURSO_DATABASE_URL or TURSO_AUTH_TOKEN")
+
+    if args.since:
+        since = args.since
+    else:
+        since = (datetime.now(timezone.utc) - timedelta(days=30)).strftime("%Y-%m-%d")
+
+    print(f"Quina Care 404 report — since {since} UTC\n")
+
+    humans = top_paths(url, token, since, args.limit, is_bot=False)
+    print(fmt_table(f"Top {args.limit} 404s (human traffic)", humans))
+
+    if args.include_bots:
+        print()
+        bots = top_paths(url, token, since, args.limit, is_bot=True)
+        print(fmt_table(f"Top {args.limit} 404s (bot traffic)", bots))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -86,6 +86,24 @@ export async function ensureSchema(): Promise<void> {
     `CREATE INDEX IF NOT EXISTS idx_app_errors_source ON app_errors(source)`,
     `CREATE INDEX IF NOT EXISTS idx_app_errors_created ON app_errors(created_at)`,
     `CREATE INDEX IF NOT EXISTS idx_app_errors_level ON app_errors(level)`,
+    // 404 / missing-page log. WordPress -> Astro migration left stale
+    // URLs in the wild; this table captures every 404 hit so we can
+    // pick the most-requested ones and turn them into redirects.
+    // is_bot is a tagged guess from the User-Agent, never a filter —
+    // both bot and human rows are kept so the heuristic can be
+    // re-evaluated later without losing data.
+    `CREATE TABLE IF NOT EXISTS page_misses (
+      id         INTEGER PRIMARY KEY AUTOINCREMENT,
+      path       TEXT NOT NULL,
+      referrer   TEXT,
+      user_agent TEXT,
+      language   TEXT,
+      is_bot     INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
+    `CREATE INDEX IF NOT EXISTS idx_page_misses_created ON page_misses(created_at)`,
+    `CREATE INDEX IF NOT EXISTS idx_page_misses_path ON page_misses(path)`,
+    `CREATE INDEX IF NOT EXISTS idx_page_misses_bot ON page_misses(is_bot)`,
   ]);
   migrated = true;
 }

--- a/src/lib/pageMisses.ts
+++ b/src/lib/pageMisses.ts
@@ -1,0 +1,56 @@
+import { getDb, ensureSchema } from "./db";
+
+// User-Agent fragments that strongly indicate non-human traffic.
+// Conservative on purpose — false positives are cheap (we still keep
+// every row), false negatives are the only thing that pollutes the
+// "human" view. Refine the regex over time as Turso shows new actors.
+const BOT_UA =
+  /bot|crawler|spider|slurp|curl|wget|python|node-fetch|axios|httpclient|java\/|go-http|libwww|lighthouse|headlesschrome|puppeteer|playwright|httrack|scanner|monitor|facebookexternalhit|twitterbot|telegram|whatsapp|line\/|skypeuripreview|discordbot|monitis|pingdom|uptimerobot|ahrefs|semrush|moz\.com|petalbot|mj12bot|bytespider|nuclei|nikto|zgrab|masscan|sqlmap|go-resty|okhttp|apache-httpclient/i;
+
+/**
+ * Tag a User-Agent as bot or human. Conservative — empty/missing UA
+ * is treated as bot (real browsers always send one). This is just a
+ * stored hint; the raw UA is also kept so the classification can be
+ * revisited at query time.
+ */
+export function isLikelyBot(userAgent: string | null | undefined): boolean {
+  if (!userAgent) return true;
+  return BOT_UA.test(userAgent);
+}
+
+export interface LogPageMissInput {
+  /** Pathname plus query string of the missed URL. */
+  path: string;
+  /** document.referrer from the client, if any. */
+  referrer?: string | null;
+  /** User-Agent header (server-supplied, not client). */
+  userAgent?: string | null;
+  /** Accept-Language header. */
+  language?: string | null;
+}
+
+/**
+ * Append a 404 hit to the page_misses table. Best-effort: a logging
+ * failure must never propagate out of the beacon handler.
+ */
+export async function logPageMiss(input: LogPageMissInput): Promise<void> {
+  try {
+    await ensureSchema();
+    const db = getDb();
+    await db.execute({
+      sql: `INSERT INTO page_misses
+              (path, referrer, user_agent, language, is_bot)
+            VALUES (?, ?, ?, ?, ?)`,
+      args: [
+        input.path.slice(0, 2000),
+        input.referrer ? input.referrer.slice(0, 2000) : null,
+        input.userAgent ? input.userAgent.slice(0, 500) : null,
+        input.language ? input.language.slice(0, 100) : null,
+        isLikelyBot(input.userAgent) ? 1 : 0,
+      ],
+    });
+  } catch (err) {
+    // Bottom of the chain — only console.warn so we never recurse.
+    console.warn("[page-misses] logPageMiss failed:", err);
+  }
+}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -106,6 +106,31 @@ const t = useTranslations(lang);
   <Footer />
 </Layout>
 
+<script is:inline>
+  // Beacon every 404 hit to /api/page-misses/log so we can build a
+  // redirect table from the WordPress URLs visitors still ask for.
+  // sendBeacon is fire-and-forget, won't delay rendering or block
+  // navigation. The server-side handler adds UA + Accept-Language.
+  (function () {
+    try {
+      navigator.sendBeacon(
+        "/api/page-misses/log",
+        new Blob(
+          [
+            JSON.stringify({
+              path: location.pathname + location.search,
+              referrer: document.referrer || null,
+            }),
+          ],
+          { type: "application/json" },
+        ),
+      );
+    } catch {
+      /* sendBeacon unavailable — not critical */
+    }
+  })();
+</script>
+
 <style>
   .error-code {
     animation: fadeInUp 0.8s cubic-bezier(0.22, 1, 0.36, 1) both;

--- a/src/pages/api/page-misses/log.ts
+++ b/src/pages/api/page-misses/log.ts
@@ -1,0 +1,57 @@
+export const prerender = false;
+
+import type { APIRoute } from "astro";
+import { logPageMiss } from "../../../lib/pageMisses";
+
+interface Body {
+  path?: string;
+  referrer?: string;
+}
+
+const MAX_BODY = 4000;
+const MAX_PER_MIN = 120; // 404 beacons can spike; keep the cap roomy
+
+let count = 0;
+let windowStart = Date.now();
+function allow(): boolean {
+  const now = Date.now();
+  if (now - windowStart > 60_000) {
+    windowStart = now;
+    count = 0;
+  }
+  if (count >= MAX_PER_MIN) return false;
+  count++;
+  return true;
+}
+
+/**
+ * Client beacon endpoint for the 404 page. The browser POSTs the
+ * requested path and document.referrer; the server enriches with the
+ * User-Agent and Accept-Language headers (more reliable than client-
+ * supplied) before writing to page_misses.
+ */
+export const POST: APIRoute = async ({ request }) => {
+  if (!allow()) return new Response("Rate limit", { status: 429 });
+
+  let body: Body;
+  try {
+    const text = await request.text();
+    if (text.length > MAX_BODY) return new Response("Too big", { status: 413 });
+    body = JSON.parse(text) as Body;
+  } catch {
+    return new Response("Bad", { status: 400 });
+  }
+
+  if (!body.path || typeof body.path !== "string") {
+    return new Response("Bad", { status: 400 });
+  }
+
+  await logPageMiss({
+    path: body.path,
+    referrer: body.referrer ?? null,
+    userAgent: request.headers.get("user-agent"),
+    language: request.headers.get("accept-language"),
+  });
+
+  return new Response("OK", { status: 200 });
+};


### PR DESCRIPTION
WordPress to Astro migration left stale URLs in the wild; this captures every 404 hit so the top requested paths can be turned into redirects in astro.config.mjs. Adds a page_misses table, a logPageMiss helper with a conservative bot heuristic, a rate-limited /api/page-misses/log beacon endpoint, an inline script on the 404 page that fires the beacon via sendBeacon, and a top-paths report script. is_bot is stored as a tag, never a filter on insert, so both human and bot rows are kept and the heuristic can be re-evaluated later without losing data.