### PR TITLE
Fix Mollie reconciliation cron not firing (#17)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,15 @@
 [build.environment]
   NODE_VERSION = "22.22.3"
 
+# Without this block, Netlify can skip the user-authored functions in
+# netlify/functions/ when the @astrojs/netlify adapter is already
+# publishing the SSR handler under .netlify/v1/functions/ — the
+# Frameworks API output becomes the sole functions surface and the
+# scheduled cron is never registered. Declaring the directory
+# explicitly keeps both function trees discoverable.
+[functions]
+  directory = "netlify/functions"
+
 [[headers]]
   for = "/*"
   [headers.values]

--- a/netlify/functions/cron-reconcile.mts
+++ b/netlify/functions/cron-reconcile.mts
@@ -5,21 +5,39 @@
 // Requires URL (set by Netlify automatically) and CRON_SECRET (set in
 // the site env). Without CRON_SECRET this is a no-op so the endpoint
 // stays unreachable from outside.
+//
+// Discoverability: this file relies on netlify.toml's [functions]
+// directory block. Without that, the @astrojs/netlify adapter's
+// .netlify/v1/ output can shadow netlify/functions/ at deploy time
+// and this scheduled function is never registered.
 
 export default async () => {
   const base = process.env.URL || process.env.DEPLOY_URL;
   const secret = process.env.CRON_SECRET;
-  if (!base || !secret) {
-    console.warn("[cron-reconcile] URL or CRON_SECRET not set, skipping");
-    return new Response("Not configured", { status: 503 });
+  if (!base) {
+    console.warn("[cron-reconcile] URL/DEPLOY_URL missing, skipping");
+    return new Response("URL missing", { status: 503 });
   }
-  const res = await fetch(`${base}/api/cron/reconcile`, {
-    method: "POST",
-    headers: { "x-cron-secret": secret },
-  });
-  const body = await res.text();
-  console.log(`[cron-reconcile] ${res.status} ${body}`);
-  return new Response(body, { status: res.status });
+  if (!secret) {
+    console.warn("[cron-reconcile] CRON_SECRET not set in Netlify env, skipping");
+    return new Response("CRON_SECRET missing", { status: 503 });
+  }
+  const target = `${base}/api/cron/reconcile`;
+  console.log(`[cron-reconcile] POST ${target}`);
+  try {
+    const res = await fetch(target, {
+      method: "POST",
+      headers: { "x-cron-secret": secret },
+    });
+    const body = await res.text();
+    console.log(`[cron-reconcile] ${res.status} ${body}`);
+    return new Response(body, { status: res.status });
+  } catch (err) {
+    console.error("[cron-reconcile] fetch failed:", err);
+    return new Response("fetch failed", { status: 502 });
+  }
 };
 
-export const config = { schedule: "@hourly" };
+// Use canonical 5-field cron over "@hourly" — Netlify documents the
+// 5-field form as the supported syntax; the @-shorthand is best-effort.
+export const config = { schedule: "0 * * * *" };

--- a/src/pages/api/cron/reconcile.ts
+++ b/src/pages/api/cron/reconcile.ts
@@ -55,6 +55,22 @@ async function classifyAbandonment(
  * shared secret in the x-cron-secret header so the URL is not callable
  * by the public.
  */
+// GET is a low-trust liveness probe — it confirms the endpoint exists
+// and shows whether the cron secret is configured server-side, without
+// requiring the caller to know the secret. Useful for debugging when
+// the Netlify scheduled function isn't observably firing.
+export const GET: APIRoute = async () => {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      endpoint: "api/cron/reconcile",
+      cronSecretConfigured: Boolean(cronSecret),
+      mollieApiKeyConfigured: Boolean(mollieApiKey),
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+};
+
 export const POST: APIRoute = async ({ request }) => {
   if (!cronSecret) {
     return new Response("Cron not configured", { status: 503 });


### PR DESCRIPTION
Closes #17.

## Root cause (STAR)

- **Situation**: `netlify/functions/cron-reconcile.mts` declares `schedule: "@hourly"` and POSTs to `/api/cron/reconcile`. The endpoint is implemented correctly. Yet the production cron never runs.
- **Task**: figure out why Netlify never invokes it.
- **Action**: ran `npm run build` and inspected the deploy artefacts. The `@astrojs/netlify` adapter writes its SSR handler under `.netlify/v1/functions/ssr/` and emits `.netlify/v1/config.json` with no mention of user functions. `netlify.toml` had no `[functions]` block. When the Frameworks API output (`.netlify/v1/`) is the only declared functions surface for a build, the deploy pipeline can skip the legacy `netlify/functions/` tree — so `cron-reconcile.mts` is never registered as scheduled.
- **Result**: declare `netlify/functions/` explicitly so it coexists with the adapter's `.netlify/v1/functions/`. Swap the `@hourly` shorthand for the canonical 5-field cron expression Netlify documents as supported.

## Changes

- `netlify.toml`: add `[functions] directory = "netlify/functions"` with a comment explaining the adapter interaction.
- `netlify/functions/cron-reconcile.mts`:
  - Cron expression `@hourly` → `0 * * * *`.
  - Distinct log lines for the two skip reasons (URL missing vs CRON_SECRET missing).
  - Wraps the inner fetch in try/catch so a network blip is recorded, not swallowed.
- `src/pages/api/cron/reconcile.ts`: add a no-op `GET` handler that returns `{ ok, cronSecretConfigured, mollieApiKeyConfigured }`. Low-trust liveness probe — no DB writes, no secret echo — so a deploy can be verified without anyone needing the cron secret.

## Test plan

- [ ] After merge, on the next prod deploy, confirm `cron-reconcile` appears under Site → Functions in Netlify and is tagged "Scheduled".
- [ ] Wait an hour. The function logs should show `[cron-reconcile] POST https://quinacare.org/api/cron/reconcile` followed by a status line.
- [ ] If the log shows `CRON_SECRET not set in Netlify env`, set `CRON_SECRET` in Site env (any 32+ char random string) and confirm `/api/cron/reconcile` (GET) reflects `cronSecretConfigured: true`.
- [ ] Verify `donations-report` (the existing script) shows stale `pending` rows clearing into `expired` / `canceled` / `paid` after a few hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)