### PR TITLE
Synchronize all news posts across NL/EN/ES (77/77/77)

### DIFF
--- a/src/content/news/en/2021/bequest.mdoc
+++ b/src/content/news/en/2021/bequest.mdoc
@@ -1,0 +1,19 @@
+---
+title: "Quina Care needs your help – Bequests"
+date: 2021-04-13
+status: publish
+slug: "bequest"
+translationKey: "nalatenschap"
+author: "Quina Care"
+excerpt: "You can support Quina Care financially in various ways — through a gift or a donation, periodic or one-off."
+language: "en"
+---
+
+You can support Quina Care financially in various ways — through a gift or a donation, periodic or one-off. But something you may not think of as readily is that you can also support us through a bequest. As a foundation with ANBI status, Quina Care is exempt from inheritance tax, so we can devote your entire bequest to our mission.
+
+Are you considering a bequest to Quina Care and would you like more information, or do you have any questions? Please feel free to contact our treasurer, Yvonne van der Ende.
+
+Contact details for Yvonne van der Ende:
+
+- email: [yvonne.vanderende@quinacare.org](mailto:yvonne.vanderende@quinacare.org)
+- phone: 06-51985480

--- a/src/content/news/en/2024/merlijn-hutteman.mdoc
+++ b/src/content/news/en/2024/merlijn-hutteman.mdoc
@@ -1,15 +1,15 @@
 ---
 title: "Merlijn Hutteman"
 date: 2024-02-14
-status: draft
+status: publish
 slug: "merlijn-hutteman"
 translationKey: "merlijn-hutteman"
 author: "Yvonne"
-excerpt: "” The taken-for-granted quality of healthcare here in the Netherlands is unfortunately not as evident in many places around the world.”Merlijn Hutteman, board member Quina CareI am pleased to..."
+excerpt: "I am pleased to introduce myself as a new board member of the Quina Care Foundation. My name is Merlijn Hutteman, and I reside and work in Nijmegen."
 language: "en"
 featured_image: "../../../../assets/media/2024/03/Merlijn-Hutteman.jpg"
 ---
 
-*" The taken-for-granted quality of healthcare here in the Netherlands is unfortunately not as evident in many places around the world."*
-**Merlijn Hutteman, board member Quina Care**
+> "The taken-for-granted quality of healthcare here in the Netherlands is unfortunately not as evident in many places around the world."
+
 I am pleased to introduce myself as a new board member of the Quina Care Foundation. My name is Merlijn Hutteman, and I reside and work in Nijmegen. I am affiliated as a gastrointestinal and oncological surgeon at Radboudumc, where my focus lies primarily on treating patients with esophageal and thyroid cancer. The taken-for-granted quality of healthcare here in the Netherlands is unfortunately not as evident in many places around the world. The mission of Jacob and Carolien, as well as the achievements already accomplished by Quina Care, deeply inspire me. I am thrilled to join the board of Quina Care to assist in expanding the activities of the hospital in Puerto el Carmen, aiming to provide the people of Putumayo with the medical care they deserve.

--- a/src/content/news/en/2024/miel-bartels.mdoc
+++ b/src/content/news/en/2024/miel-bartels.mdoc
@@ -1,27 +1,31 @@
 ---
 title: "Miel Bartels"
 date: 2024-02-14
-status: draft
+status: publish
 slug: "miel-bartels"
 translationKey: "miel-bartels"
 author: "Yvonne"
-excerpt: "” Doctor, do you like coconuts?”Miel Bartels, voluntary medical doctorA woman in her late forties sits across from me. She is a single mother, running one of the many breakfast and lunch spots in the..."
+excerpt: "A woman in her late forties sits across from me. She is a single mother, running one of the many breakfast and lunch spots in the village."
 language: "en"
 featured_image: "../../../../assets/media/2024/02/Foto-Miel-2-scaled.jpg"
 ---
 
-*" Doctor, do you like coconuts?"*
-**Miel Bartels, voluntary medical doctor**
+> "Doctor, do you like coconuts?"
+
 A woman in her late forties sits across from me. She is a single mother, running one of the many breakfast and lunch spots in the village. Every day, she wakes up at 4:00 am to prepare breakfast for her customers, often finishing late in the afternoon. I see her every few weeks; she suffers from chronic joint inflammations. Her children also visit me regularly for diarrhea and anaemia. Unfortunately, she cannot afford the medications I prescribe. Fortunately, Quina Care has a fund to provide healthcare for the poorest in this region.
 
 Today, at the end of the consultation, she suddenly asks me, 'Doctor, do you like coconuts?' 'Uh, yes?' I respond somewhat surprised. She slowly stands up and retrieves a plastic bag with six coconuts from behind the door. 'For you, doctor, for the good care.' Although coconuts are not scarce in the jungle, the gesture touches me. I gratefully accept the fruits and place them in my imaginary box: next to the two chickens, the eggs, and the five-dollar tip for the first delivery I assisted. A box that fills up much faster here in Puerto el Carmen than it would in the Netherlands.
+
 {% image src="/media/2024/02/Foto-Miel-1-scaled.jpg" align="center" /%}
+
 A day in the hospital begins at half-past eight in the morning with a handover and educational moment. When the doors open, Marta's 'buenos días doctor!' always sounds first – and the loudest – always accompanied by a big smile. A delightful counterbalance when you've had a long night, and the alarm went off at half-past six, a bit too early. Marta helps with cleaning the hospital. Something she does with love and dedication – and when it's busy, she works longer without complaining. 'I thank God every day for the opportunity to be part of the Quina Care family, financially independent, and able to care for my daughter.' It's just one example of how the hospital plays such a crucial role not only for the patients but also for the staff in the community.
 
 Work and personal life intertwine. While in the Netherlands, it's not common to give your private number to patients, it turns out to be the least complicated option here. On my birthday, a family from the village surprised me at the hospital, singing 'happy birthday' with cake! And during every trip to the village, I would either walk into an ambush of curious children or be asked for a consultation while walking. I quickly got used to it and found it amusing, although sometimes I longed for an anonymous return trip to Albert Heijn when I had nothing at home and really craved something.
 
 The Quina Care team is a close-knit group. Special or festive occasions such as birthdays and achieved milestones are celebrated like a family. The social highlight of the week is the sports session on Thursday afternoon. Not only the staff but also their relatives, ex-relatives, adopted children, and dogs are welcome. There's exercising and lots of laughter.
+
 {% image src="/media/2024/02/Foto-Miel-3-scaled.jpg" align="center" /%}
+
 After six months, I take with me a lot of experience and cherished memories of the people in Puerto el Carmen and the Quina Care team.
 
 Miel Bartels

--- a/src/content/news/en/2024/yvonne-van-der-ende-blaszyk.mdoc
+++ b/src/content/news/en/2024/yvonne-van-der-ende-blaszyk.mdoc
@@ -1,24 +1,28 @@
 ---
 title: "Yvonne van der Ende-Blaszyk"
 date: 2024-02-12
-status: draft
+status: publish
 slug: "yvonne-van-der-ende-blaszyk"
 translationKey: "yvonne-van-der-ende-blaszyk"
 author: "Yvonne"
-excerpt: "” Such visits reaffirm the purpose! “ Yvonne van der Ende-Blaszyk, treasurer Quina CareThis summer, I visited the hospital again. It had been over a year since my last visit, and there were..."
+excerpt: "This summer, I visited the hospital again. It had been over a year since my last visit, and there were noticeable changes."
 language: "en"
 featured_image: "../../../../assets/media/2024/01/hospital-San-Miguel-scaled.jpg"
 ---
 
-*" Such visits reaffirm the purpose! "*
-**Yvonne van der Ende-Blaszyk, treasurer Quina Care**
+> "Such visits reaffirm the purpose!"
+
 This summer, I visited the hospital again. It had been over a year since my last visit, and there were noticeable changes. The nursing departments had just opened, so I had the opportunity to explore them. I also had the chance to meet the new nurses.
 
 A ride in the elevator was a must, especially considering that the hospital's elevator is the only one in Puerto el Carmen.
 
 What hadn't changed was the warm welcome by Rosa, our receptionist, and the other staff members. The staff maintains a positive atmosphere, and they collaborate professionally. Every time I'm there, I'm impressed by everyone's dedication. On the day of arrival, we were able to join the staff's weekly soccer game. It was quite competitive, and everyone was welcome to participate. It was a lot of fun!
+
+{% image-row %}
 {% image src="/media/2024/01/Ritje-met-de-lift-scaled.jpg" align="center" /%}
 {% image src="/media/2024/01/Stoel-voor-het-maken-van-een-uitstrijkje-scaled.jpg" align="center" /%}
+{% /image-row %}
+
 During my visit, I had the opportunity to join a medical outreach. We visited a village at the tri-border area of Ecuador/Peru/Colombia, aptly named Tres Fronteras. There, we collected blood samples from about 50 adults and children for malaria and dengue research in collaboration with the AMC in the Netherlands. We also performed Pap smears on over 20 women for HPV research. It was quite challenging to create a space for this in the separate room behind the village hall, a stark contrast to the setup in the Netherlands. As a non-medical person, I, along with my husband and children, provided a typical Dutch lunch (healthy sandwiches) for all the people who had come to the village hall for blood or Pap smear tests, including our staff, of course!
 
 Furthermore, during my visit, I discussed numerous administrative matters with Carolien and Jacob. It was enjoyable and beneficial to do this physically rather than through the app, email, or phone. My husband and children were also busy working on further developing the Electronic Patient Record, taking photos for sponsors and the website, and repairing small electrical appliances and beds.
@@ -28,4 +32,5 @@ This was my third visit, and Puerto el Carmen is starting to feel a bit like a s
 As board members, we work daily from the Netherlands and have close contact with Carolien, Jacob, and the chairman of the Ecuadorian board, keeping us well-informed about what is happening at Hospital San Miguel. However, being physically present, seeing the renovations with our own eyes, talking to the staff, and feeling the dynamics and occasional chaos is truly enriching. Such visits reaffirm the purpose! I hope to visit again in 2024.
 
 Yvonne van der Ende-Blaszyk
+
 {% image src="/media/2024/01/Winkel-in-het-dorp-scaled.jpg" align="center" /%}

--- a/src/content/news/es/2021/legado.mdoc
+++ b/src/content/news/es/2021/legado.mdoc
@@ -1,0 +1,19 @@
+---
+title: "Quina Care necesita su ayuda – Legado"
+date: 2021-04-13
+status: publish
+slug: "legado"
+translationKey: "nalatenschap"
+author: "Quina Care"
+excerpt: "Puede apoyar económicamente a Quina Care de varias maneras: mediante una donación, periódica o única."
+language: "es"
+---
+
+Puede apoyar económicamente a Quina Care de varias maneras: mediante una donación, periódica o única. Pero algo en lo que quizá no piense tan rápido es que también puede apoyarnos mediante un legado. Como fundación con estatus ANBI, Quina Care está exenta del impuesto de sucesiones, por lo que podemos destinar la totalidad de su legado a nuestra misión.
+
+¿Está considerando dejar un legado a Quina Care y desea más información o tiene alguna pregunta? No dude en ponerse en contacto con nuestra tesorera, Yvonne van der Ende.
+
+Datos de contacto de Yvonne van der Ende:
+
+- correo electrónico: [yvonne.vanderende@quinacare.org](mailto:yvonne.vanderende@quinacare.org)
+- teléfono: 06-51985480

--- a/src/content/news/es/2024/merlijn-hutteman.mdoc
+++ b/src/content/news/es/2024/merlijn-hutteman.mdoc
@@ -10,6 +10,6 @@ language: "es"
 featured_image: "../../../../assets/media/2024/03/Merlijn-Hutteman.jpg"
 ---
 
-> "Lamentablemente, la obviedad de la atención médica aquí en los Países Bajos no es tan evidente en muchos lugares del mundo.""
+> "Lamentablemente, la obviedad de la atención médica aquí en los Países Bajos no es tan evidente en muchos lugares del mundo."
 
 Me gustaría presentarme como nuevo director de la fundación Quina Care. Mi nombre es Merlijn Hutteman y vivo y trabajo en Nimega. Soy cirujano gastrointestinal y oncológico en el Centro Médico de la Universidad de Radboud, donde me enfoco principalmente en el tratamiento de pacientes con cáncer de esófago y tiroides. Lamentablemente, la obviedad de la atención médica aquí en los Países Bajos no es tan evidente en muchos lugares del mundo. La misión de Jacob y Carolien y los logros ya obtenidos por Quina Care me inspiran profundamente. Me parece fantástico unirme a la directiva de Quina Care para ayudar a expandir las actividades del hospital en Puerto el Carmen para brindar la atención médica que las personas de Putumayo merecen.

--- a/src/content/news/es/2024/miel-bartels.mdoc
+++ b/src/content/news/es/2024/miel-bartels.mdoc
@@ -10,7 +10,7 @@ language: "es"
 featured_image: "../../../../assets/media/2024/02/Foto-Miel-2-scaled.jpg"
 ---
 
-> "Doctor, ¿le gustan los cocos?""
+> "Doctor, ¿le gustan los cocos?"
 
 Frente a mí hay una mujer, de unos cuarenta años. Es madre soltera y tiene uno de los muchos lugares de desayunos y almuerzos en el pueblo. Todos los días se levanta a las 4.00 am para preparar el desayuno para sus clientes y a menudo no termina hasta tarde en la tarde. La veo cada par de semanas: sufre de inflamaciones crónicas en las articulaciones. Por cierto, sus hijos también vienen a verme con frecuencia, debido a problemas de diarrea y anemia. La madre no puede pagar los medicamentos que le prescribo a la familia. Afortunadamente, Quina Care tiene un fondo para brindar atención médica a los más necesitados de esta región.
 

--- a/src/content/news/es/2024/yvonne-van-der-ende-blaszyk.mdoc
+++ b/src/content/news/es/2024/yvonne-van-der-ende-blaszyk.mdoc
@@ -10,7 +10,7 @@ language: "es"
 featured_image: "../../../../assets/media/2024/01/hospital-San-Miguel-scaled.jpg"
 ---
 
-> "¡Una visita como esta deja aún más claro para qué se hace todo esto!""
+> "¡Una visita como esta deja aún más claro para qué se hace todo esto!"
 
 El verano pasado volví a visitar el hospital. Había pasado más de un año desde mi última visita, por lo que varias cosas habían cambiado. Las salas de enfermería acababan de abrirse, así que pude verlas enseguida. También conocí a las nuevas enfermeras.
 
@@ -18,9 +18,10 @@ Por supuesto, no podía faltar un paseo en el ascensor, sobre todo sabiendo que 
 
 Lo que no cambió fue la cálida bienvenida de Rosa, nuestra recepcionista, y los demás miembros del personal. Hay un buen ambiente entre el personal y se trabaja de manera profesional. Cada vez que estoy allí, me impresiona la entrega de todos. Directamente el día de llegada, pudimos participar en el partido de fútbol semanal del personal. Fue bastante fanático y todos eran bienvenidos a participar. ¡Fue genial!
 
+{% image-row %}
 {% image src="/media/2024/01/Ritje-met-de-lift-scaled.jpg" align="center" /%}
-
 {% image src="/media/2024/01/Stoel-voor-het-maken-van-een-uitstrijkje-scaled.jpg" align="center" /%}
+{% /image-row %}
 
 Durante mi visita, tuve la oportunidad de unirme a una brigada médica. Fuimos a un pueblo en el punto trifinio entre Ecuador, Perú y Colombia, muy apropiadamente llamado Tres Fronteras. Allí tomamos muestras de sangre a unas 50 personas, tanto adultos como niños, para la investigación de malaria y dengue que realizamos en colaboración con el AMC en los Países Bajos. También se tomaron frotis a más de 20 mujeres para la investigación del VPH. Fue toda una improvisación crear un lugar para esto en una sala aparte que hay detrás del centro comunitario. Muy diferente a todo en los Países Bajos. Como no médico, organicé junto con mi esposo e hijos un almuerzo holandés (sándwiches saludables) para todas las personas que vinieron especialmente al centro comunitario para que les tomaran sangre o un frotis. ¡Y para nuestro personal propio, por supuesto!
 

--- a/src/content/news/nl/2021/nalatenschap.mdoc
+++ b/src/content/news/nl/2021/nalatenschap.mdoc
@@ -3,6 +3,7 @@ title: "Quina Care heeft uw hulp nodig – Nalatenschap"
 date: 2021-04-13
 status: publish
 slug: "nalatenschap"
+translationKey: "nalatenschap"
 author: "Quina Care"
 excerpt: "U kunt Quina Care op verschillende manieren financieel steunen. Dat kan middels een schenking of een donatie, periodiek of eenmalig."
 language: "nl"

--- a/src/content/news/nl/2024/merlijn-hutteman.mdoc
+++ b/src/content/news/nl/2024/merlijn-hutteman.mdoc
@@ -1,15 +1,15 @@
 ---
 title: "Merlijn Hutteman"
 date: 2024-02-14
-status: draft
+status: publish
 slug: "merlijn-hutteman"
 translationKey: "merlijn-hutteman"
 author: "Yvonne"
-excerpt: "” De vanzelfsprekendheid van de kwaliteit van zorg hier in Nederland is helaas op veel plekken van de wereld niet zo vanzelfsprekend.”Merlijn Hutteman, bestuurslid Quina CareGraag stel ik me voor als..."
+excerpt: "Graag stel ik me voor als nieuw bestuurslid van stichting Quina Care. Mijn naam is Merlijn Hutteman en woon en werk in Nijmegen."
 language: "nl"
 featured_image: "../../../../assets/media/2024/03/Merlijn-Hutteman.jpg"
 ---
 
-*" De vanzelfsprekendheid van de kwaliteit van zorg hier in Nederland is helaas op veel plekken van de wereld niet zo vanzelfsprekend."*
-**Merlijn Hutteman, bestuurslid Quina Care**
+> "De vanzelfsprekendheid van de kwaliteit van zorg hier in Nederland is helaas op veel plekken van de wereld niet zo vanzelfsprekend."
+
 Graag stel ik me voor als nieuw bestuurslid van stichting Quina Care. Mijn naam is Merlijn Hutteman en woon en werk in Nijmegen. Ik ben verbonden als gastro-intestinaal en oncologisch chirurg aan het Radboudumc, waar ik me vooral richt op de behandeling van patiënten met slokdarm- en schildklierkanker. De vanzelfsprekendheid van de kwaliteit van zorg hier in Nederland is helaas op veel plekken van de wereld niet zo vanzelfsprekend. De missie van Jacob en Carolien en de al behaalde resultaten van Quina Care inspireren me diep. Ik vind het fantastisch om toe te mogen treden tot het bestuur van Quina Care om te helpen de activiteiten van het ziekenhuis in Puerto el Carmen verder uit te bouwen om de mensen van Putumayo de medische zorg te kunnen bieden die ze verdienen.

--- a/src/content/news/nl/2024/miel-bartels.mdoc
+++ b/src/content/news/nl/2024/miel-bartels.mdoc
@@ -1,27 +1,31 @@
 ---
 title: "Miel Bartels"
 date: 2024-02-14
-status: draft
+status: publish
 slug: "miel-bartels"
 translationKey: "miel-bartels"
 author: "Quina Care"
-excerpt: "” Dokter, houdt u van kokosnoten?” Miel Bartels, vrijwillige artsTegenover mij zit een vrouw, eind veertig. Ze is een alleenstaande moeder, en runt een van de vele ontbijt- en lunchzaakjes in het..."
+excerpt: "Tegenover mij zit een vrouw, eind veertig. Ze is een alleenstaande moeder, en runt een van de vele ontbijt- en lunchzaakjes in het dorp."
 language: "nl"
 featured_image: "../../../../assets/media/2024/02/Foto-Miel-2-scaled.jpg"
 ---
 
-*" Dokter, houdt u van kokosnoten?"*
-**Miel Bartels, vrijwillige arts**
+> "Dokter, houdt u van kokosnoten?"
+
 Tegenover mij zit een vrouw, eind veertig. Ze is een alleenstaande moeder, en runt een van de vele ontbijt- en lunchzaakjes in het dorp. Elke dag staat ze om 4.00 uur op om het ontbijt voor haar klanten voor te bereiden en vaak is ze pas laat in de middag klaar. Ik zie haar om de paar weken: ze lijdt aan chronische ontstekingen in haar gewrichten. Haar kinderen komen overigens ook geregeld bij me, vanwege diarree en bloedarmoede. De medicijnen die ik het gezin voorschrijf kan de moeder niet betalen. Gelukkig heeft Quina Care een fonds om ook de allerarmsten in deze regio van zorg te voorzien.
 
 Vandaag, aan het einde van het consult, vraagt ze me plotseling: 'dokter, houdt u van kokosnoten?' 'Ehh, ja?', reageer ik enigszins verbaasd. Ze staat langzaam op, en haalt vanachter de deur een plastic tas met zes kokosnoten tevoorschijn. 'Voor u, dokter, voor de goede zorgen.' Hoewel kokosnoten niet schaars zijn in de jungle, raakt het gebaar me. Ik neem de steenvruchten dankbaar aan en plaats ze in mijn denkbeeldige kistje: naast de twee kippen, de eieren, en de vijf dollar fooi voor de eerste bevalling die ik hielp begeleiden. Een kistje dat zich hier in Puerto el Carmen met veel grotere snelheid vult dan het in Nederland zou doen.
+
 {% image src="/media/2024/02/Foto-Miel-1-scaled.jpg" align="center" /%}
+
 Een dag in het ziekenhuis begint om half acht 's ochtends met een overdracht en onderwijs moment. Als de deuren open gaan klinkt de 'buenos días doctor!' van Marta altijd het eerst – en het luidst – en wordt altijd vergezeld met een grote glimlach. Een heerlijk contragewicht als je een lange nacht hebt gehad en de wekker om half zeven eigenlijk net te vroeg ging. Marta werkt in de schoonmaak van het ziekenhuis. Dat doet ze met liefde en toewijding – en als het druk is, werkt ze zonder mopperen langer door. 'Ik dank God elke dag dat ik de kans heb gekregen om van de Quina Care-familie deel uit te maken, financieel onafhankelijk te zijn en zo voor mijn dochter te kunnen zorgen.' Het is maar een van de voorbeelden van hoe het ziekenhuis niet alleen voor de patiënten maar ook voor de medewerkers zo'n belangrijke rol speelt in de gemeenschap.
 
 Werk en privé lopen dwars door elkaar. Terwijl het in Nederland niet gebruikelijk is om je privénummer aan patiënten te geven, blijkt dat hier toch wel de minst ingewikkelde optie. Op mijn verjaardag kwam een familie uit het dorp als verrassing naar het ziekenhuis om 'fijne verjaardag' voor mij te zingen, met taart en al! En tijdens elk tripje naar het dorp liep ik wel in een 'hinderlaag' van nieuwsgierige kinderen of werd ik al lopend gevraagd een consult te geven. Ik raakte daar snel aan gewend en vond het ook wel grappig, al heb ik soms ook wel verlangd naar een anoniem retourtje Albert Heijn als ik niks in huis had en wel echt even trek had in iets.
 
 Het team van Quina Care is een hechte groep. Bijzondere of feestelijke gelegenheden zoals verjaardagen en gehaalde mijlpalen worden gevierd als familie. Het sociale hoogtepunt van de week is de sportsessie op donderdagmiddag. Niet alleen de staf, maar ook hun verwanten, ex-verwanten, geadopteerde kinderen en honden zijn welkom. Er wordt gesport en veel gelachen.
+
 {% image src="/media/2024/02/Foto-Miel-3-scaled.jpg" align="center" /%}
+
 Zo neem ik na zes maanden heel veel ervaring en dierbare herinneringen mee aan de mensen in Puerto el Carmen en het Quina Care team.
 
 Miel Bartels

--- a/src/content/news/nl/2024/yvonne-van-der-ende-blaszyk.mdoc
+++ b/src/content/news/nl/2024/yvonne-van-der-ende-blaszyk.mdoc
@@ -1,23 +1,28 @@
 ---
 title: "Yvonne van der Ende-Blaszyk"
 date: 2024-01-11
-status: draft
+status: publish
 slug: "yvonne-van-der-ende-blaszyk"
 translationKey: "yvonne-van-der-ende-blaszyk"
 author: "Yvonne"
-excerpt: "” Zo’n bezoek maakt weer even extra duidelijk waar je het allemaal voor doet! “   Yvonne van der Ende-Blaszyk, penningmeester Quina CareAfgelopen zomer heb ik weer een bezoek gebracht aan het..."
+excerpt: "Afgelopen zomer heb ik weer een bezoek gebracht aan het ziekenhuis. Het was ruim een jaar geleden sinds mijn vorige bezoek en er was dan ook het nodige veranderd."
 language: "nl"
 featured_image: "../../../../assets/media/2024/01/hospital-San-Miguel-scaled.jpg"
 ---
 
-*" Zo'n bezoek maakt weer even extra duidelijk waar je het allemaal voor doet! "***Yvonne van der Ende-Blaszyk, penningmeester Quina Care**
+> "Zo'n bezoek maakt weer even extra duidelijk waar je het allemaal voor doet!"
+
 Afgelopen zomer heb ik weer een bezoek gebracht aan het ziekenhuis. Het was ruim een jaar geleden sinds mijn vorige bezoek en er was dan ook het nodige veranderd. De verpleegafdelingen waren net geopend, dus die kon ik meteen bekijken. En ook kennismaken met de nieuwe verpleegkundigen.
 
 Een ritje in de lift mocht natuurlijk niet ontbreken, zeker als je weet dat de lift in het ziekenhuis de enige lift is in Puerto el Carmen.
 
 Wat niet veranderd was, was de hartelijke ontvangst door Rosa, onze receptioniste en de andere personeelsleden. Onder het personeel hangt een goede sfeer en er wordt op een professionele manier samengewerkt. Iedere keer als ik er ben, ben ik weer onder de indruk van de inzet van iedereen. Direct op de dag van aankomst konden we meedoen met de wekelijkse voetbalpot die het personeel onderling speelt. Dat ging er behoorlijk fanatiek aan toe en iedereen was welkom om mee te doen. Super leuk was dat!
+
+{% image-row %}
 {% image src="/media/2024/01/Ritje-met-de-lift-scaled.jpg" align="center" /%}
 {% image src="/media/2024/01/Stoel-voor-het-maken-van-een-uitstrijkje-scaled.jpg" align="center" /%}
+{% /image-row %}
+
 Tijdens mijn bezoek heb ik de gelegenheid gehad om mee te gaan op brigade. We zijn naar een dorpje geweest op het drielandenpunt Ecuador/Peru/Colombia, heel toepasselijk Tres Fronteras genaamd. Daar hebben we bij zo'n 50 volwassenen en kinderen bloed mogen afnemen voor het malaria en dengue onderzoek dat we doen in samenwerking met het AMC in Nederland. Ook zijn er uitstrijkjes gemaakt bij ruim 20 vrouwen voor het HPV onderzoek. Het was behoorlijk improviseren om een plek hiervoor te creëren in de aparte ruimte achter het dorpshuis. Hoe anders dan in Nederland allemaal. Als niet medici heb ik samen met mijn man en kinderen een oer-Hollandse lunch (broodjes gezond) verzorgd voor alle mensen die speciaal naar het dorpshuis waren gekomen om bloed of een uitstrijkje te laten afnemen. En voor onze eigen staf natuurlijk!
 
 Verder heb ik tijdens mijn bezoek samen met Carolien en Jacob een heleboel administratieve zaken kunnen bespreken en het was leuk en nuttig om dat nu ook eens fysiek te kunnen doen en niet allemaal via de app, e-mail of telefoon.
@@ -29,4 +34,5 @@ Dit was mijn derde bezoek en dan gaat Puerto el Carmen ook een beetje als tweede
 Als bestuursleden zijn we dagelijks aan het werk vanuit Nederland en hebben we nauw contact met Carolien en Jacob en de voorzitter van het Ecuadoriaanse bestuur waardoor we goed op de hoogte zijn van wat er allemaal speelt in hospital San Miguel. Maar er dan weer even echt bij zijn en met eigen ogen zien hoe de verbouwingen zijn geworden, met de personeelsleden praten en de dynamiek en soms hectiek voelen, dat is toch wel een verrijking. Zo'n bezoek maakt weer even extra duidelijk waar je het allemaal voor doet! Ik hoop ook in 2024 weer een bezoek te kunnen brengen.
 
 Yvonne van der Ende-Blaszyk
+
 {% image src="/media/2024/01/Winkel-in-het-dorp-scaled.jpg" align="center" /%}


### PR DESCRIPTION
Audited per-language post coverage and synchronized all news posts so every one exists, published, in **all three languages**. Counts go from NL 74 / EN 73 / ES 76 → **77 / 77 / 77**, with every `translationKey` group complete and no duplicates.

## The gaps that were closed
The audit (by `translationKey`) found exactly four mismatches:

| Post | Was | Fix |
|---|---|---|
| `merlijn-hutteman` | ES live, NL/EN draft | Publish + clean NL/EN |
| `miel-bartels` | ES live, NL/EN draft | Publish + clean NL/EN |
| `yvonne-van-der-ende-blaszyk` | ES live, NL/EN draft | Publish + clean NL/EN |
| `nalatenschap` | NL-only, no key | Backfill EN (`bequest`) + ES (`legado`), add translationKey |

Staff cleanup = pull-quote → blockquote, dropped the bold attribution, rebuilt excerpts, doubled-quote fix, and the yvonne image-row.

## Note
Branched off `feat/complete-translations` (PR #32, not yet merged), since the audit reflects that branch's backfills/merges — so this is stacked on PR #32 and should merge after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
