### PR TITLE
Add Amsterdam hub to the 2026 Putumayo Loop

### DIFF
--- a/src/data/putumayoLoop.ts
+++ b/src/data/putumayoLoop.ts
@@ -305,6 +305,16 @@ export const editions: EditionConfig[] = [
         // Hulst runs kids (1 km), 5 km, 10 km, and 21 km — no full marathon.
         distances: ["kids", "5k", "10k", "half"],
       },
+      {
+        id: "amsterdam",
+        name: "Amsterdam",
+        city: "Amsterdam",
+        country: "NL",
+        coords: [52.3676, 4.9041],
+        captain: "Miel Bartels",
+        captainEmail: "mielbartels@gmail.com",
+        // No `distances` set: Amsterdam offers every distance.
+      },
     ],
     target: 25000,
   },


### PR DESCRIPTION
Adds Amsterdam as a fourth hub for the active 2026 edition in `src/data/putumayoLoop.ts`.

- Coordinator: Miel Bartels (mielbartels@gmail.com) — also receives the signup notification mail for this hub, alongside the run manager.
- Coordinates: 52.3676, 4.9041 (city centre, same pin the 2025 edition used for Amsterdam).
- No `distances` set, so the hub offers every distance (1/5/10/21/42 km).

All three language routes read the same list, so no per-language content changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDvqcjwp1QsGV1Krft7ns8