### PR TITLE
Add the Nijmegen hub to the 2026 Putumayo Loop

### DIFF
--- a/src/data/putumayoLoop.ts
+++ b/src/data/putumayoLoop.ts
@@ -316,6 +316,17 @@ export const editions: EditionConfig[] = [
         // Amsterdam runs the 10 km only.
         distances: ["10k"],
       },
+      {
+        id: "nijmegen",
+        name: "Nijmegen",
+        city: "Nijmegen",
+        country: "NL",
+        coords: [51.8126, 5.8372],
+        captain: "Bregje Doesburg",
+        captainEmail: "bregjedoesburg@gmail.com",
+        // Nijmegen runs 5 km, 10 km, and 21 km — no kids run, no full marathon.
+        distances: ["5k", "10k", "half"],
+      },
     ],
     target: 25000,
   },

--- a/src/pages/en/putumayo-run.astro
+++ b/src/pages/en/putumayo-run.astro
@@ -292,7 +292,7 @@ const excerpt = t("putumayoLoop.heroSubtitle");
         {t("putumayoLoop.hubsSubtitle")}
       </h2>
     </div>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
       {
         hubs.map((hub) => (
           <button

--- a/src/pages/es/putumayo-carrera.astro
+++ b/src/pages/es/putumayo-carrera.astro
@@ -292,7 +292,7 @@ const excerpt = t("putumayoLoop.heroSubtitle");
         {t("putumayoLoop.hubsSubtitle")}
       </h2>
     </div>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
       {
         hubs.map((hub) => (
           <button

--- a/src/pages/putumayo-loop.astro
+++ b/src/pages/putumayo-loop.astro
@@ -292,7 +292,7 @@ const excerpt = t("putumayoLoop.heroSubtitle");
         {t("putumayoLoop.hubsSubtitle")}
       </h2>
     </div>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
       {
         hubs.map((hub) => (
           <button


### PR DESCRIPTION
Closes #96.

Adds the Nijmegen hub to the 2026 edition: **Bregje Doesburg** (bregjedoesburg@gmail.com), running **5 km, 10 km and 21 km** — no kids run, no full marathon.

Hubs are entirely data-driven, so the hub itself is a single entry in `src/data/putumayoLoop.ts`. Setting `captainEmail` means Bregje also receives a notification for every Nijmegen signup, matching the other hubs.

Five hubs plus the "start your own hub" tile makes six cards, which left an orphan on the desktop row of five. The hub grid on the three language landing pages goes from `lg:grid-cols-5` to `lg:grid-cols-3`, giving two even rows. Mobile and tablet are unchanged (one column, then two from `sm`).

The per-edition pages (`putumayo-loop/[year].astro` and siblings) have their own hub grid and no invitation tile; they are left as they were.

`tsc --noEmit` clean, 23/23 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDvqcjwp1QsGV1Krft7ns8
