### PR TITLE
Resolve missed routes from the 404 log

### DIFF
--- a/src/data/missesRedirects.mjs
+++ b/src/data/missesRedirects.mjs
@@ -3,33 +3,27 @@
 export default {
   "/donate": "/en/donate",
   "/hospital-san-miguel": "/ziekenhuis",
-  "/een-ziekenhuis-in-het-amazonegebied-van-ecuador":
-    "/actueel/een-ziekenhuis-in-het-amazonegebied-van-ecuador",
+  "/een-ziekenhuis-in-het-amazonegebied-van-ecuador": "/actueel/een-ziekenhuis-in-het-amazonegebied-van-ecuador",
   "/en/about-us": "/en/about",
   "/en/word-vrijwilliger": "/en/become-volunteer",
   "/news/nieuwe-website": "/actueel/nieuwe-website",
   "/news/putumayo-loop-2026-launch": "/actueel/putumayo-loop-2026-launch",
   "/fundraisers/demi-en-thomas": "/acties/demi-en-thomas",
   "/actueel/looking-for-equipment": "/actueel/we-zoeken-apparatuur",
-  "/doneer/matthijs-altena-running-4-running-costs":
-    "/acties/matthijs-altena-running-4-running-costs",
+  "/doneer/matthijs-altena-running-4-running-costs": "/acties/matthijs-altena-running-4-running-costs",
   "/fundraisers/karin-martens": "/acties/karin-martens",
   "/en/en-ecuador/ecuador": "/en/news/ecuador",
   "/en/about-us/organization": "/en/organization",
-  "/en/en-blogs-vlogs/there-is-always-a-different-way":
-    "/en/news/there-is-always-a-different-way",
+  "/en/en-blogs-vlogs/there-is-always-a-different-way": "/en/news/there-is-always-a-different-way",
   "/en/en-ecuador/putumayo": "/en/news/putumayo",
   "/en/en-blogs-vlogs/toilets-or-sockets": "/en/news/toilets-or-sockets",
   "/ecuador/putumayo": "/actueel/putumayo",
-  "/en/en-blogs-vlogs/build-in-times-of-crisis":
-    "/en/news/build-in-times-of-crisis",
+  "/en/en-blogs-vlogs/build-in-times-of-crisis": "/en/news/build-in-times-of-crisis",
   "/en/maria-priscila-chacon-de-la-portilla-3": "/en/staff",
   "/projecten/hospital-equipment": "/projecten/ziekenhuisapparatuur",
-  "/en/whats-happening-in-puerto-el-carmen":
-    "/en/news/whats-happening-in-puerto-el-carmen",
+  "/en/whats-happening-in-puerto-el-carmen": "/en/news/whats-happening-in-puerto-el-carmen",
   "/en/hpv-screening": "/en/projects/hpv-screening",
-  "/en/en-blogs-vlogs/clearing-boarding-school":
-    "/en/news/clearing-boarding-school",
+  "/en/en-blogs-vlogs/clearing-boarding-school": "/en/news/clearing-boarding-school",
   "/en/quina-care-is-growing": "/en/news/quina-care-is-growing",
   "/es/es-ecuador/ecuador": "/es/noticias/ecuador",
   "/en/en-blogs-vlogs/guayaquil": "/en/news/guayaquil",
@@ -37,30 +31,23 @@ export default {
   "/en/hospital-san-miguel-2/staff": "/en/staff",
   "/news/nootdorp4life-sponsorrit": "/actueel/nootdorp4life-sponsorrit",
   "/rotterdam-marathon": "/acties/rotterdam-marathon",
-  "/es/news/floortje-naar-het-einde-van-de-wereld":
-    "/es/noticias/floortje-naar-het-einde-van-de-wereld",
+  "/es/news/floortje-naar-het-einde-van-de-wereld": "/es/noticias/floortje-naar-het-einde-van-de-wereld",
   "/over-ons/organisatie": "/organisatie",
   "/steun-hospital-san-miguel-en-doe-een-donatie": "/doneer",
   "/en/clinical-wards-are-open": "/en/news/clinical-wards-are-open",
   "/es/acerca-de-nosotros/organizacion": "/es/organizacion",
   "/anbi": "/actueel/anbi",
   "/en/about-us/policy-plan": "/en/news/policy-plan",
-  "/en/hospital-san-miguel-has-become-reality":
-    "/en/news/hospital-san-miguel-has-become-reality",
-  "/en/en-blogs-vlogs/well-functiong-laboratory-vital":
-    "/en/news/well-functiong-laboratory-vital",
-  "/es/es-blogs-vlogs/construir-en-tiempos-de-crisis":
-    "/es/noticias/construir-en-tiempos-de-crisis",
+  "/en/hospital-san-miguel-has-become-reality": "/en/news/hospital-san-miguel-has-become-reality",
+  "/en/en-blogs-vlogs/well-functiong-laboratory-vital": "/en/news/well-functiong-laboratory-vital",
+  "/es/es-blogs-vlogs/construir-en-tiempos-de-crisis": "/es/noticias/construir-en-tiempos-de-crisis",
   "/es/es-ecuador/putumayo": "/es/noticias/putumayo",
-  "/blogs-vlogs/hospital-san-miguel-is-realiteit-geworden":
-    "/actueel/hospital-san-miguel-is-realiteit-geworden",
+  "/blogs-vlogs/hospital-san-miguel-is-realiteit-geworden": "/actueel/hospital-san-miguel-is-realiteit-geworden",
   "/es/news/nootdorp4life-sponsorrit": "/es/noticias/nootdorp4life-sponsorrit",
-  "/news/floortje-naar-het-einde-van-de-wereld":
-    "/actueel/floortje-naar-het-einde-van-de-wereld",
+  "/news/floortje-naar-het-einde-van-de-wereld": "/actueel/floortje-naar-het-einde-van-de-wereld",
   "/miel-bartels": "/actueel/miel-bartels",
   "/marilu-isabel-calderon-hidalgo": "/actueel/marilu-isabel-calderon-hidalgo",
-  "/patricia-coromoto-picon-nadales":
-    "/actueel/patricia-coromoto-picon-nadales",
+  "/patricia-coromoto-picon-nadales": "/actueel/patricia-coromoto-picon-nadales",
   "/karen-vanessa-tamba-jurado": "/actueel/karen-vanessa-tamba-jurado",
   "/magali-maribel-chacon-aguilar": "/actueel/magali-maribel-chacon-aguilar",
   "/jessica-rodriguez-valencia": "/actueel/jessica-rodriguez-valencia",
@@ -79,8 +66,9 @@ export default {
   "/blogs-vlogs/matthijs-altena": "/actueel/matthijs-altena",
   "/elza-heemskerk": "/actueel/elza-heemskerk",
   "/en/hanna-hazenberg": "/en/news/hanna-hazenberg",
-  "/es/un-hospital-en-la-region-amazonica-de-ecuador":
-    "/es/noticias/un-hospital-en-la-region-amazonica-de-ecuador",
+  "/es/un-hospital-en-la-region-amazonica-de-ecuador": "/es/noticias/un-hospital-en-la-region-amazonica-de-ecuador",
   "/es/maria-vanessa-davila-campos": "/es/noticias/maria-vanessa-davila-campos",
   "/es/andrea-diaz-saenz": "/es/noticias/andrea-diaz-saenz",
+  "/actueel/actueel/jessica-rodriguez-valencia": "/actueel/jessica-rodriguez-valencia",
+  "/blogs-vlogs/ricardo-salazar": "/actueel/ricardo-salazar"
 };


### PR DESCRIPTION
Routine refresh of the missed-route redirects from the live `page_misses` log, via `/resolve-404s`.

## Run summary

| | |
| --- | --- |
| Human, non-local 404 paths | 41 |
| Ignored local/dev misses | 0 |
| Drafts published | **0** — nothing matched |
| Redirects in the file | 68 → **70** |
| Skipped (junk / already resolved / no match) | 39 |
| Rows cleared from `page_misses` | 115 |

Snapshot of the cleared rows kept at `/tmp/404-snapshot.json`.

## The two new redirects

```
/actueel/actueel/jessica-rodriguez-valencia  ->  /actueel/jessica-rodriguez-valencia
/blogs-vlogs/ricardo-salazar                ->  /actueel/ricardo-salazar
```

A doubled `/actueel/` segment, and an old WordPress `/blogs-vlogs/` path — both follow patterns already established in the file. I verified both targets: the posts exist, are `status: publish`, and return 200 on the live site.

Nothing needed curating this run — no cross-language targets, no redirects landing on an old blog post instead of a real page, and no `-N` collision slugs.

## About the diff size

The diff reads as 16 insertions / 28 deletions, which looks like entries were lost. They were not: 14 entries that Prettier had wrapped across two lines are now on one line. The key count goes 68 → 70, with **no removals and no changed targets** — I diffed the parsed key/value sets to confirm rather than trusting the line diff.

## Validation

`npx astro check` — 0 errors, 0 warnings, 0 hints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDvqcjwp1QsGV1Krft7ns8
