### PR TITLE
Fix the signup schema drift and filter third-party error noise

### DIFF
--- a/scripts/migrate-putumayo-loop.mjs
+++ b/scripts/migrate-putumayo-loop.mjs
@@ -36,8 +36,12 @@ async function tryAlter(sql) {
   }
 }
 
+// The one definition of this table. Both ensureSchema() (fresh database)
+// and dropStaleForeignKey() (rebuild) use it, so the two can never drift
+// apart again — they had, and `age` went missing from both, which is what
+// broke live signups with "no column named age".
 const SUBSCRIBERS_SCHEMA = `
-  CREATE TABLE putumayo_loop_subscribers (
+  CREATE TABLE IF NOT EXISTS putumayo_loop_subscribers (
     id            INTEGER PRIMARY KEY AUTOINCREMENT,
     external_id   TEXT UNIQUE,
     edition_year  INTEGER NOT NULL,
@@ -52,6 +56,7 @@ const SUBSCRIBERS_SCHEMA = `
     distance      TEXT,
     emergency_contact_name  TEXT,
     emergency_contact_phone TEXT,
+    age           INTEGER,
     signed_up_at  TEXT NOT NULL,
     created_at    TEXT NOT NULL DEFAULT (datetime('now'))
   )
@@ -87,35 +92,30 @@ async function dropStaleForeignKey() {
     `ALTER TABLE putumayo_loop_subscribers RENAME TO putumayo_loop_subscribers_old`,
   );
   await db.execute(SUBSCRIBERS_SCHEMA);
+  // Copy every column the old and new tables share, rather than a fixed
+  // list: the hardcoded one silently dropped emergency contacts and ages
+  // for existing signups, because it was never updated when those columns
+  // were added. Intersecting also keeps this safe for older databases that
+  // predate them.
+  const [oldCols, newCols] = await Promise.all([
+    db.execute(`PRAGMA table_info(putumayo_loop_subscribers_old)`),
+    db.execute(`PRAGMA table_info(putumayo_loop_subscribers)`),
+  ]);
+  const newNames = new Set(newCols.rows.map((r) => r.name));
+  const shared = oldCols.rows
+    .map((r) => r.name)
+    .filter((name) => newNames.has(name));
+  const cols = shared.join(", ");
   await db.execute(`
-    INSERT INTO putumayo_loop_subscribers
-      (id, external_id, edition_year, first_name, last_name, email,
-       hub_id, lat, lng, location, count, distance, signed_up_at, created_at)
-    SELECT id, external_id, edition_year, first_name, last_name, email,
-       hub_id, lat, lng, location, count, distance, signed_up_at, created_at
-    FROM putumayo_loop_subscribers_old
+    INSERT INTO putumayo_loop_subscribers (${cols})
+    SELECT ${cols} FROM putumayo_loop_subscribers_old
   `);
   await db.execute(`DROP TABLE putumayo_loop_subscribers_old`);
   await db.execute(`PRAGMA foreign_keys = ON`);
 }
 
 async function ensureSchema() {
-  await db.execute(`CREATE TABLE IF NOT EXISTS putumayo_loop_subscribers (
-      id            INTEGER PRIMARY KEY AUTOINCREMENT,
-      external_id   TEXT UNIQUE,
-      edition_year  INTEGER NOT NULL,
-      first_name    TEXT,
-      last_name     TEXT,
-      email         TEXT,
-      hub_id        TEXT,
-      lat           REAL,
-      lng           REAL,
-      location      TEXT,
-      count         INTEGER NOT NULL DEFAULT 1,
-      distance      TEXT,
-      signed_up_at  TEXT NOT NULL,
-      created_at    TEXT NOT NULL DEFAULT (datetime('now'))
-    )`);
+  await db.execute(SUBSCRIBERS_SCHEMA);
   await dropStaleForeignKey();
   await db.execute(
     `CREATE INDEX IF NOT EXISTS idx_subscribers_edition ON putumayo_loop_subscribers (edition_year)`,
@@ -130,6 +130,12 @@ async function ensureSchema() {
   );
   await tryAlter(
     `ALTER TABLE putumayo_loop_subscribers ADD COLUMN emergency_contact_phone TEXT`,
+  );
+  // Age of the runner, captured for the kids run. The signup endpoint has
+  // written this since the kids run was added; the migration never created
+  // it, so a database built from this script rejected every signup.
+  await tryAlter(
+    `ALTER TABLE putumayo_loop_subscribers ADD COLUMN age INTEGER`,
   );
 }
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -128,9 +128,19 @@ const structuredData = {
           /WKWebView API client did not respond/,
           /showSearchResults/,
           /operation was aborted|AbortError/,
+          // Microsoft Office / Outlook injects this into pages it opens;
+          // it was the single loudest entry in the log and never came
+          // from a stack of ours.
+          /^Object Not Found Matching Id:/,
+          // Android in-app browsers (Facebook, Instagram, LinkedIn) tear
+          // down their JS bridge on navigation and log the failed call.
+          /Error invoking postMessage/,
+          // iOS Safari, raised when a request is still in flight as the
+          // page goes away. Benign, and not something a fix can reach.
+          /InvalidStateError/,
         ];
         const NOISE_SRC =
-          /cloudflareinsights\.com|extension:\/\/|webkit-masked-url/;
+          /cloudflareinsights\.com|extension:\/\/|webkit-masked-url|iabjs:\/\//;
         function isNoise(message, context) {
           for (let i = 0; i < NOISE_MSG.length; i++) {
             if (NOISE_MSG[i].test(message || "")) return true;


### PR DESCRIPTION
Triage of the 65 rows in `app_errors`, via `/app_errors`. Five distinct groups: one real bug, four third-party noise.

## Triage

| Group | Rows | Decision |
| --- | ---: | --- |
| `api/putumayo-loop/signup` — `Turso insert failed … no column named kids_age` | 15 | **Root cause fixed** (see below) |
| `Object Not Found Matching Id:N, MethodName:update` (MS Office/Outlook, on `/doneer`) | 39 | Filtered at source |
| `Error invoking postMessage: Java …` (Android in-app browser, `iabjs://`) | 6 | Filtered at source |
| `InvalidStateError` (iOS Safari, request in flight on unload) | 5 | Filtered at source |

## The signup failures

Fifteen people tried to register for the Putumayo Loop on 23–24 August and got "Could not save your signup". The insert named `kids_age`, which the table does not have. `c67fe03` already renamed it to `age`, and I confirmed against the live table that signups work now — it has `age`, no `kids_age`.

What that fix missed is the migration script, which still describes a table nobody can sign up to. Three problems were sitting there:

1. **`age` appears in no definition in the script.** A database built from it rejects every signup, exactly as production did. Now defined, with an idempotent `ALTER` for existing databases.
2. **The table was defined twice** — in `SUBSCRIBERS_SCHEMA` and again inline in `ensureSchema()` — and the two had already drifted, with only the first carrying the emergency contact columns. `ensureSchema()` now uses the shared definition, so they cannot diverge again.
3. **The stale-FK rebuild copied a hardcoded column list** that was never updated when columns were added. Running it would have silently dropped emergency contacts and ages from every existing signup. It now carries over the columns the old and new tables share, which is also safe for older databases that predate those columns.

This aligns the script with production rather than changing production.

## The noise

50 of 65 rows came from software that isn't ours, which buries the 15 that mattered. Three patterns added to the existing `NOISE_MSG` list in `Layout.astro`, plus `iabjs://` to `NOISE_SRC`. Checked against the exact messages from the log: all 50 suppressed, while server errors and errors from our own `/_astro/` bundles still report.

## Validation

`npx astro check` — 0 errors, 0 warnings, 0 hints. Migration script parses clean.

## Nobody was actually lost

Worth checking rather than assuming: the 15 failures came from only **2 distinct people**, who retried 9 and 6 times against the error. Both appear in the 2026 subscribers table, so both are registered and no follow-up is needed.

That does say something about the experience, though — two people hit "Could not save your signup" fifteen times between them before it stuck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDvqcjwp1QsGV1Krft7ns8
